### PR TITLE
Transform markdown code in a mannual page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,9 @@ Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0001-5670-2640")),
     person("Craig", "McGowan", email = "mcgowan.cj@gmail.com", role = "ctb",
-           comment = c(ORCID = "0000-0002-6298-0185"))
+           comment = c(ORCID = "0000-0002-6298-0185")),
+    person("JJ", "Chen", email = "jiajia.chern@gmail.com", role = "ctb",
+           comment = c(ORCID = "0000-0001-8482-8398"))
   )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: The 'U.S.' Centers for Disease Control ('CDC') maintains a portal

--- a/R/agd-ipt.r
+++ b/R/agd-ipt.r
@@ -4,6 +4,7 @@
 #' public health laboratories by influenza virus type and subtype/lineage. Laboratory data
 #' from multiple seasons and different age groups is provided.
 #'
+#' @md
 #' @references
 #' - [CDC FluView Portal](https://gis.cdc.gov/grasp/fluview/fluportaldashboard.html)
 #' - [AGD IPT Portal](https://gis.cdc.gov/grasp/fluview/flu_by_age_virus.html)

--- a/man/age_group_distribution.Rd
+++ b/man/age_group_distribution.Rd
@@ -7,10 +7,10 @@
 age_group_distribution(years = NULL)
 }
 \arguments{
-\item{years}{a vector of years to retrieve data for (i.e. `2014` for CDC
+\item{years}{a vector of years to retrieve data for (i.e. \code{2014} for CDC
 flu season 2014-2015). CDC has data for this API going back to 1997.
-Default value (`NULL`) means retrieve **all** years. NOTE: if you
-happen to specify a 2-digit season value (i.e. `57` == 2017-2018)
+Default value (\code{NULL}) means retrieve \strong{all} years. NOTE: if you
+happen to specify a 2-digit season value (i.e. \code{57} == 2017-2018)
 the function is smart enough to retrieve by season ID vs convert that
 to a year.}
 }
@@ -23,6 +23,8 @@ from multiple seasons and different age groups is provided.
 age_group_distribution(years=2015)
 }
 \references{
-- [CDC FluView Portal](https://gis.cdc.gov/grasp/fluview/fluportaldashboard.html)
-- [AGD IPT Portal](https://gis.cdc.gov/grasp/fluview/flu_by_age_virus.html)
+\itemize{
+\item \href{https://gis.cdc.gov/grasp/fluview/fluportaldashboard.html}{CDC FluView Portal}
+\item \href{https://gis.cdc.gov/grasp/fluview/flu_by_age_virus.html}{AGD IPT Portal}
+}
 }


### PR DESCRIPTION
I was reading the help file for `age_group_distribution` and noticed that the markdown code was not employed, so I added a `@md` tag, and run `devtools::document()`.