### PR TITLE
consistent week naming for `pi_mortality` and `ilinet`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Authors@R: c(
     person("Sebastian", "Meyer", email = "seb.meyer@fau.de", role = "ctb",
            comment = c(ORCID = "0000-0002-1791-9449")),
     person("James", "Turtle", email = "jturtle@predsci.com", role = "ctb",
-           comment = c(ORCID = "0000-0003-0735-7769"))
+           comment = c(ORCID = "0000-0003-0735-7769")),
+    person("Andrew", "Bates", role = "ctb")
   )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: The 'U.S.' Centers for Disease Control and Prevention (CDC) maintain

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+#cdcfluview 0.9.1
+
+- renamed `pi_mortality` columns regarding the week to `week_*` instead of `wk_*`
+  for consistency with `ilinet` (#21).
+
 # cdcfluview 0.9.0
 
 - fix bug in epiweek computation in ilinet() thanks to a bug report by @jturtle (#19)

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,4 +1,4 @@
-utils::globalVariables(c(".", "mmwrid", "season", "seasonid", "week_start"))
+utils::globalVariables(c(".", "mmwrid", "season", "seasonid", "week_start", "wk_start", "wk_end", "year_wk_num"))
 
 # CDC U.S. region names to ID map
 .region_map <- c(national=3, hhs=1, census=2, state=5)

--- a/R/pi-mortality.r
+++ b/R/pi-mortality.r
@@ -37,6 +37,8 @@
 #'        the function is smart enough to retrieve by season ID vs convert that
 #'        to a year.
 #' @note Queries for "state" and "region" are not necessarily as "instantaneous" as other API endpoints and can near or over 30s retrieval delays.
+#'
+#' For consistency with \code{\link{ilinet}} columns indicating the week now contain 'week' instead of the previously abbreviation 'wk'.
 #' @references
 #' - [Pneumonia and Influenza Mortality Surveillance Portal](https://gis.cdc.gov/grasp/fluview/mortality.html)
 #' @export
@@ -144,6 +146,12 @@ pi_mortality <- function(coverage_area=c("national", "state", "region"), years=N
   xdf$number_pneumonia <- to_num(xdf$number_pneumonia)
   xdf$all_deaths <- to_num(xdf$all_deaths)
   xdf$Total_PnI <- to_num(xdf$Total_PnI)
+  xdf <- xdf %>%
+    dplyr::rename(
+      week_start = wk_start,
+      week_end = wk_end,
+      year_week_num = year_wk_num
+    )
   xdf <- .mcga(xdf)
 
   xdf

--- a/man/pi_mortality.Rd
+++ b/man/pi_mortality.Rd
@@ -48,6 +48,8 @@ calculated at the national and regional level and by age group.
 }
 \note{
 Queries for "state" and "region" are not necessarily as "instantaneous" as other API endpoints and can near or over 30s retrieval delays.
+
+For consistency with \code{\link{ilinet}} columns indicating the week now contain 'week' instead of the previously abbreviation 'wk'.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
I have

- renamed returned columns in `pi_mortaility` to `week_start`, `week_end`, `year_week_num`
- added myself as a contributor in DESCRIPTION
- added a note in `pi_mortaility` documentation reflecting the change
- updated NEWS.md to reflect the change
- added `wk_start`, `wk_end`, `year_wk_num` to global variables list in `aaa.R`

I was getting a R CMD check note about no  global variables `wk_start`, `wk_end`, `year_wk_num` which is why I added them to `aaa.R`. I'm not sure if this was the correct thing to do but the note goes away.

For the package startup message, I wasn't sure if you wanted this to show up every time (current startup message doesn't) so I did not change this.


closes #21
