### PR TITLE
minor fix to hospitalizations() internals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Encoding: UTF-8
 Title: Retrieve Flu Season Data from the United States Centers for Disease Control 
     and Prevention ('CDC') 'FluView' Portal
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Date: 2022-11-22
 Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 

--- a/R/hospital.r
+++ b/R/hospital.r
@@ -44,7 +44,7 @@ hospitalizations <- function(surveillance_area=c("flusurv", "eip", "ihsp"),
          call.=FALSE)
   }
 
-  hosp <- list(res = res$default_data, meta = meta)
+  hosp <- list(res = meta$default_data, meta = meta)
 
   age_df <- setNames(hosp$meta$master_lookup, c("variable", "value_id", "parent_id", "label", "color", "enabled"))
   age_df <- age_df[(age_df$variable == "Age" | age_df$value_id == 0) & !is.na(age_df$value_id),]


### PR DESCRIPTION
@hrbrmstr thank you for developing and maintaining this package!

i have been using the `hospitalizations()` function to retrieve FluSurv-NET data. it looks like a recent update may have had a minor bug in this function. the problem was discussed in an issue thread (https://github.com/hrbrmstr/cdcfluview/issues/30#issuecomment-1329912762) ... i am putting together this PR to implement the suggestion from @IMcGovern-Seqirus

the code below should demonstrate the issue with the code currently on main branch => the fix as implemented on my fork (and incoming via this PR).

thanks again for creating this package. i am happy to make any adjustments to the PR as you see fit.

``` r
remotes::install_github("hrbrmstr/cdcfluview")
.rs.restartR()
packageVersion("cdcfluview")
#> [1] '1.0.0.9000'
library(cdcfluview)
all_hosp <- hospitalizations()
#> Error in hospitalizations(): object 'res' not found
```

``` r
remotes::install_github("vpnagraj/cdcfluview")
.rs.restartR()
packageVersion("cdcfluview")
#> [1] '1.0.0.9001'
library(cdcfluview)
all_hosp <- hospitalizations()
max(all_hosp$weekend)
#> [1] "2023-04-29"
```

and `devtools::check()` on local machine comes back clean with 0 ERRORs, 0 WARNINGs, 0 NOTEs